### PR TITLE
Search ctest executable in cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
  - wrong version in CHANGELOG
+ - set active configuration default in test executor if not found 
 
+### Added
+
+ - delete .vsix packages when clearing build directories
+ - search for ctest program in CMake cache dir if ctest in CMakeCache.txt is not found
+
+### Changed
+
+ - changed log messages in test discoverer and executor
+ 
 ## 3.1.0 - 2018-01-10
 
 ### Added

--- a/CTestAdapter/CTestAdapterConfig.cs
+++ b/CTestAdapter/CTestAdapterConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Xml.Serialization;
 
@@ -8,14 +9,14 @@ namespace CTestAdapter
   [Serializable]
   public class CTestAdapterConfig
   {
-    private string _cacheDir;
-    private string _configFileName;
+    private string _cacheDir = "";
+    private string _configFileName = "";
 
     private bool _dirty = false;
 
-    private string _activeConfiguration;
-    private string _ctestExecutable;
-    private string _cmakeConfigurationTypes;
+    private string _activeConfiguration = "";
+    private string _ctestExecutable = "";
+    private string _cmakeConfigurationTypes = "";
 
     public string CacheDir
     {
@@ -169,6 +170,18 @@ namespace CTestAdapter
         }
       }
       return false;
+    }
+
+    public bool TrySetActiveConfigFromConfigTypes()
+    {
+      var typeString = this._cmakeConfigurationTypes;
+      var types = typeString.Split(';');
+      if (!types.Any())
+      {
+        return false;
+      }
+      this._activeConfiguration = types.First();
+      return true;
     }
   }
 }

--- a/CTestAdapter/CTestAdapterConstants.cs
+++ b/CTestAdapter/CTestAdapterConstants.cs
@@ -15,6 +15,8 @@ namespace CTestAdapter
 
     public static readonly Guid OutputWindow = new Guid("231F0144-E723-4FD5-A62B-DADCFF615067");
 
+    public const string CTestExecutableName = "ctest.exe";
+
     public const string CMakeCacheFilename = "CMakeCache.txt";
     public const string CTestTestFileName = "CTestTestfile.cmake";
     public const string CTestAdapterConfigFileName = "CTestAdapter.config";

--- a/CTestAdapter/CTestDiscoverer.cs
+++ b/CTestAdapter/CTestDiscoverer.cs
@@ -49,7 +49,22 @@ namespace CTestAdapter
                 CTestAdapterConfig.ReadFromCache(cacheDir);
       if (null == cfg)
       {
+        this.Log(TestMessageLevel.Error, "could not create CTestAdapterConfig");
         return;
+      }
+      // make sure a configuration is set
+      if (!cfg.ActiveConfiguration.Any())
+      {
+        if (cfg.TrySetActiveConfigFromConfigTypes())
+        {
+          this.Log(TestMessageLevel.Warning,
+            "Configuration fallback to: " + cfg.ActiveConfiguration);
+        }
+        else
+        {
+          this.Log(TestMessageLevel.Error, "could not set Configuration");
+          return;
+        }
       }
       this.Log(TestMessageLevel.Informational, "using configuration: " + cfg.ActiveConfiguration);
       var collection = TestContainerHelper.FindAllTestsWithCtest(cfg);

--- a/CTestAdapter/CTestDiscoverer.cs
+++ b/CTestAdapter/CTestDiscoverer.cs
@@ -16,18 +16,32 @@ namespace CTestAdapter
     // @todo CHECK HOW OFTEN TEST DISCOVERERS ARE INSTANTIATED!!!
     //       IS IT WORTH TO STORE INFORMATION?!?!?!?
 
+    private const string LogPrefix = "CTestDiscoverer: ";
+
+    private IMessageLogger _log = null;
+
+    private void Log(TestMessageLevel lvl, string message)
+    {
+      if (this._log == null)
+      {
+        return;
+      }
+      this._log.SendMessage(lvl, CTestDiscoverer.LogPrefix + message);
+    }
+
     public void DiscoverTests(IEnumerable<string> sources,
         IDiscoveryContext discoveryContext,
-        IMessageLogger log,
+        IMessageLogger logger,
         ITestCaseDiscoverySink discoverySink)
     {
-      log.SendMessage(TestMessageLevel.Informational, "CTestDiscoverer discovering ...");
+      this._log = logger;
+      this.Log(TestMessageLevel.Informational, "discovering ...");
       var v = sources as IList<string> ?? sources.ToList();
       // verify we have a CMakeCache.txt directory
       var cacheDir = TestContainerHelper.FindCMakeCacheDirectory(v.First());
       if (!cacheDir.Any())
       {
-        log.SendMessage(TestMessageLevel.Informational, "cmake cache not found");
+        this.Log(TestMessageLevel.Informational, "cmake cache not found");
         return;
       }
       // read parameters
@@ -37,17 +51,17 @@ namespace CTestAdapter
       {
         return;
       }
-      log.SendMessage(TestMessageLevel.Informational, "using configuration: " + cfg.ActiveConfiguration);
+      this.Log(TestMessageLevel.Informational, "using configuration: " + cfg.ActiveConfiguration);
       var collection = TestContainerHelper.FindAllTestsWithCtest(cfg);
       foreach (var source in v)
       {
-        var cases = TestContainerHelper.ParseTestContainerFile(source, log, collection, cfg.ActiveConfiguration);
+        var cases = TestContainerHelper.ParseTestContainerFile(source, this._log, collection, cfg.ActiveConfiguration);
         foreach (var c in cases)
         {
           discoverySink.SendTestCase(c.Value);
         }
       }
-      log.SendMessage(TestMessageLevel.Informational, "CTestDiscoverer discovering done");
+      this.Log(TestMessageLevel.Informational, "discovering done");
     }
   }
 }

--- a/CTestAdapter/CTestDiscoverer.cs
+++ b/CTestAdapter/CTestDiscoverer.cs
@@ -67,6 +67,19 @@ namespace CTestAdapter
         }
       }
       this.Log(TestMessageLevel.Informational, "using configuration: " + cfg.ActiveConfiguration);
+      // make sure we have a ctest executable
+      if (!File.Exists(cfg.CTestExecutable))
+      {
+        cfg.CTestExecutable = TestContainerHelper.FindCTestExe(cfg.CacheDir);
+      }
+      if (!File.Exists(cfg.CTestExecutable))
+      {
+        this.Log(TestMessageLevel.Error,
+          "ctest not found, tried: \"" + cfg.CTestExecutable + "\"");
+        return;
+      }
+      this.Log(TestMessageLevel.Informational, "using ctest binary: " + cfg.CTestExecutable);
+      // collect all existing tests by executing ctest
       var collection = TestContainerHelper.FindAllTestsWithCtest(cfg);
       foreach (var source in v)
       {

--- a/CTestAdapter/CTestExecutor.cs
+++ b/CTestAdapter/CTestExecutor.cs
@@ -60,7 +60,7 @@ namespace CTestAdapter
       this._runningFromSources = true;
       var logFileDir = this._config.CacheDir + "\\Testing\\Temporary";
       frameworkHandle.SendMessage(TestMessageLevel.Informational,
-          MessagePrefix + "logs are written to (" + CTestExecutor.ToLinkPath(logFileDir) + ")");
+          MessagePrefix + "logs are written to (" + TestContainerHelper.ToLinkPath(logFileDir) + ")");
       foreach (var s in enumerable)
       {
         var cases = TestContainerHelper.ParseTestContainerFile(s, frameworkHandle, null, this._config.ActiveConfiguration);
@@ -112,18 +112,18 @@ namespace CTestAdapter
       if (!Directory.Exists(this._config.CacheDir))
       {
         frameworkHandle.SendMessage(TestMessageLevel.Error,
-            MessagePrefix + "working directory not found: " + CTestExecutor.ToLinkPath(this._config.CacheDir));
+            MessagePrefix + "working directory not found: " + TestContainerHelper.ToLinkPath(this._config.CacheDir));
         return;
       }
       frameworkHandle.SendMessage(TestMessageLevel.Informational,
-          MessagePrefix + "working directory is " + CTestExecutor.ToLinkPath(this._config.CacheDir));
+          MessagePrefix + "working directory is " + TestContainerHelper.ToLinkPath(this._config.CacheDir));
       var logFileDir = this._config.CacheDir + "\\Testing\\Temporary";
       if (!this._runningFromSources)
       {
         frameworkHandle.SendMessage(TestMessageLevel.Informational,
             MessagePrefix + "ctest (" + this._config.CTestExecutable + ")");
         frameworkHandle.SendMessage(TestMessageLevel.Informational,
-            MessagePrefix + "logs are written to (" + CTestExecutor.ToLinkPath(logFileDir) + ")");
+            MessagePrefix + "logs are written to (" + TestContainerHelper.ToLinkPath(logFileDir) + ")");
       }
       this._proc = new Process();
       if (this._procParam == null)
@@ -188,7 +188,7 @@ namespace CTestAdapter
         if (!File.Exists(logFileName))
         {
           frameworkHandle.SendMessage(TestMessageLevel.Warning, "logfile not found: " 
-            + CTestExecutor.ToLinkPath(logFileName));
+            + TestContainerHelper.ToLinkPath(logFileName));
         }
         var content = File.ReadAllText(logFileName);
         var logFileBackup = test.FullyQualifiedName + ".log";
@@ -226,7 +226,7 @@ namespace CTestAdapter
               MessagePrefix + "END OF TEST OUTPUT FROM " + test.FullyQualifiedName);
         }
         frameworkHandle.SendMessage(TestMessageLevel.Informational,
-            MessagePrefix + "Log saved to " + CTestExecutor.ToLinkPath(logFileBackup));
+            MessagePrefix + "Log saved to " + TestContainerHelper.ToLinkPath(logFileBackup));
         frameworkHandle.RecordResult(testResult);
       }
       this._proc.Dispose();
@@ -240,11 +240,6 @@ namespace CTestAdapter
       this._config = CTestAdapterConfig.ReadFromDisk(Path.Combine(cacheDir, Constants.CTestAdapterConfigFileName)) ??
                      CTestAdapterConfig.ReadFromCache(cacheDir);
       return null != this._config;
-    }
-
-    public static string ToLinkPath(string pathName)
-    {
-      return "file://" + pathName.Replace(" ", "%20");
     }
   }
 }

--- a/CTestAdapter/CTestExecutor.cs
+++ b/CTestAdapter/CTestExecutor.cs
@@ -62,9 +62,8 @@ namespace CTestAdapter
       this._log = frameworkHandle;
       this.Log(TestMessageLevel.Informational, "running tests (src) ...");
       var enumerable = sources as IList<string> ?? sources.ToList();
-      if(!this.SetupEnvironment(enumerable.First(), frameworkHandle))
+      if(!this.SetupEnvironment(enumerable.First()))
       {
-        this.Log(TestMessageLevel.Error, "could not initialize environment (src)");
         return;
       }
       this.Log(TestMessageLevel.Informational, "using configuration: " 
@@ -93,9 +92,8 @@ namespace CTestAdapter
       }
       if (!this._runningFromSources)
       {
-        if(!this.SetupEnvironment(testCases.First().Source, frameworkHandle))
+        if(!this.SetupEnvironment(testCases.First().Source))
         {
-          this.Log(TestMessageLevel.Error, "could not initialize environment");
           return;
         }
       }
@@ -247,12 +245,17 @@ namespace CTestAdapter
       this.Log(TestMessageLevel.Informational, "running tests done");
     }
 
-    private bool SetupEnvironment(string source, IMessageLogger h)
+    private bool SetupEnvironment(string source)
     {
       var cacheDir = TestContainerHelper.FindCMakeCacheDirectory(source);
       this._config = CTestAdapterConfig.ReadFromDisk(Path.Combine(cacheDir, Constants.CTestAdapterConfigFileName)) ??
                      CTestAdapterConfig.ReadFromCache(cacheDir);
-      return null != this._config;
+      if (this._config == null)
+      {
+        this.Log(TestMessageLevel.Error, "could not initialize environment");
+        return false;
+      }
+      return true;
     }
   }
 }

--- a/CTestAdapter/CTestExecutor.cs
+++ b/CTestAdapter/CTestExecutor.cs
@@ -100,16 +100,18 @@ namespace CTestAdapter
           return;
         }
       }
+      // make sure a configuration is set
       if (!this._config.ActiveConfiguration.Any())
       {
-        // get configuration name from cmake cache, pick first found
-        var typeString = this._config.CMakeConfigurationTypes;
-        var types = typeString.Split(';');
-        if (types.Any())
+        if (this._config.TrySetActiveConfigFromConfigTypes())
         {
-          this._config.ActiveConfiguration = types.First();
           this.Log(TestMessageLevel.Warning,
-              "Configuration fallback to: " + this._config.ActiveConfiguration);
+            "Configuration fallback to: " + this._config.ActiveConfiguration);
+        }
+        else
+        {
+          this.Log(TestMessageLevel.Error, "could not set Configuration");
+          return;
         }
       }
       if (!this._config.ActiveConfiguration.Any())

--- a/CTestAdapter/CTestExecutor.cs
+++ b/CTestAdapter/CTestExecutor.cs
@@ -57,12 +57,13 @@ namespace CTestAdapter
       }
     }
 
-    public void RunTests(IEnumerable<string> sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
+    public void RunTests(IEnumerable<string> sources, IRunContext runContext,
+      IFrameworkHandle frameworkHandle)
     {
       this._log = frameworkHandle;
       this.Log(TestMessageLevel.Informational, "running tests (src) ...");
-      var enumerable = sources as IList<string> ?? sources.ToList();
-      if(!this.SetupEnvironment(enumerable.First()))
+      var sourcesList = sources as IList<string> ?? sources.ToList();
+      if(!this.SetupEnvironment(sourcesList.First()))
       {
         return;
       }
@@ -72,16 +73,18 @@ namespace CTestAdapter
       var logFileDir = this._config.CacheDir + "\\Testing\\Temporary";
       this.Log(TestMessageLevel.Informational,
           "logs are written to (" + TestContainerHelper.ToLinkPath(logFileDir) + ")");
-      foreach (var s in enumerable)
+      foreach (var source in sourcesList)
       {
-        var cases = TestContainerHelper.ParseTestContainerFile(s, frameworkHandle, null, this._config.ActiveConfiguration);
+        var cases = TestContainerHelper.ParseTestContainerFile(
+          source, frameworkHandle, null, this._config.ActiveConfiguration);
         this.RunTests(cases.Values, runContext, frameworkHandle);
       }
       this._runningFromSources = false;
       this.Log(TestMessageLevel.Informational, "running tests (src) done");
     }
 
-    public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
+    public void RunTests(IEnumerable<TestCase> tests, IRunContext runContext,
+      IFrameworkHandle frameworkHandle)
     {
       this._log = frameworkHandle;
       this.Log(TestMessageLevel.Informational, "running tests ...");

--- a/CTestAdapter/CTestExecutor.cs
+++ b/CTestAdapter/CTestExecutor.cs
@@ -114,15 +114,15 @@ namespace CTestAdapter
           return;
         }
       }
-      if (!this._config.ActiveConfiguration.Any())
+      // make sure we have a ctest executable
+      if (!File.Exists(this._config.CTestExecutable))
       {
-        this.Log(TestMessageLevel.Warning,
-            "no build configuration found");
+        this._config.CTestExecutable = TestContainerHelper.FindCTestExe(this._config.CacheDir);
       }
       if (!File.Exists(this._config.CTestExecutable))
       {
         this.Log(TestMessageLevel.Error,
-            "ctest not found: \"" + this._config.CTestExecutable + "\"");
+            "ctest not found, tried: \"" + this._config.CTestExecutable + "\"");
         return;
       }
       if (!Directory.Exists(this._config.CacheDir))

--- a/CTestAdapter/TestContainerHelper.cs
+++ b/CTestAdapter/TestContainerHelper.cs
@@ -116,7 +116,7 @@ namespace CTestAdapter
     public static Dictionary<string, TestCase> ParseTestContainerFile(string source, IMessageLogger log,
       CTestTestCollection collection, string activeConfiguration)
     {
-      log.SendMessage(TestMessageLevel.Informational, "Parsing CTest file: " + CTestExecutor.ToLinkPath(source));
+      log.SendMessage(TestMessageLevel.Informational, "Parsing CTest file: " + TestContainerHelper.ToLinkPath(source));
       var cases = new Dictionary<string, TestCase>();
       var content = File.ReadLines(source);
       var skipFoundTests = false;
@@ -216,6 +216,11 @@ namespace CTestAdapter
         }
         fileOrDirectory = info.Parent.FullName;
       }
+    }
+
+    public static string ToLinkPath(string pathName)
+    {
+      return "file://" + pathName.Replace(" ", "%20");
     }
   }
 }

--- a/CTestAdapter/TestContainerHelper.cs
+++ b/CTestAdapter/TestContainerHelper.cs
@@ -93,6 +93,26 @@ namespace CTestAdapter
       return collection;
     }
 
+    public static string FindCTestExe(string basePath)
+    {
+      var file = new FileInfo(Path.Combine(basePath, Constants.CTestExecutableName));
+      if (file.Exists)
+      {
+        return file.FullName;
+      }
+      var cdir = new DirectoryInfo(basePath);
+      var subdirs = cdir.GetDirectories();
+      foreach (var dir in subdirs)
+      {
+        var res = TestContainerHelper.FindCTestExe(dir.FullName);
+        if (res != string.Empty)
+        {
+          return res;
+        }
+      }
+      return string.Empty;
+    }
+
     public static Dictionary<string, TestCase> ParseTestContainerFile(string source, IMessageLogger log,
       CTestTestCollection collection, string activeConfiguration)
     {

--- a/ClearAllBuildDirs.bat
+++ b/ClearAllBuildDirs.bat
@@ -4,3 +4,5 @@ rmdir /S /Q  %~dp0vs11
 rmdir /S /Q  %~dp0vs12
 rmdir /S /Q  %~dp0vs14
 rmdir /S /Q  %~dp0vs15
+
+del *.vsix


### PR DESCRIPTION
If the ctest executable is not found in the path that is stored in CMakeCache.txt, the test adapter now searches for **ctest.exe** in the CMake cache directory recursively.

This is helpful, if the build tree is deployed in a different location or machine for test runs.